### PR TITLE
Feature/linters

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 2

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,42 @@
+{
+  "env": {
+    "browser": false,
+    "es6": true,
+    "jest": true
+  },
+  "extends": "eslint:recommended",
+  "parserOptions": {
+    "ecmaFeatures": {
+      "experimentalObjectRestSpread": true,
+      "jsx": true
+    },
+    "sourceType": "module"
+  },
+  "plugins": [
+      "react"
+  ],
+  "rules": {
+    "react/jsx-uses-react": 2,
+    "react/jsx-uses-vars": 2,
+    "react/react-in-jsx-scope": 2,
+    "indent": [
+      "error",
+      2
+    ],
+    "linebreak-style": [
+      "error",
+      "unix"
+    ],
+    "quotes": [
+      "error",
+      "single"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ]
+  },
+  "globals": {
+    "document": false
+  }
+}

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+eslint:
+  enabled: true
+  config_file: .eslintrc
+jshint:
+  enabled: false

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -1,0 +1,49 @@
+---
+# Use this file to configure the Overcommit hooks you wish to use. This will
+# extend the default configuration defined in:
+# https://github.com/brigade/overcommit/blob/master/config/default.yml
+#
+# At the topmost level of this YAML file is a key representing type of hook
+# being run (e.g. pre-commit, commit-msg, etc.). Within each type you can
+# customize each hook, such as whether to only run it on certain files (via
+# `include`), whether to only display output if it fails (via `quiet`), etc.
+#
+# For a complete list of hooks, see:
+# https://github.com/brigade/overcommit/tree/master/lib/overcommit/hook
+#
+# For a complete list of options that you can use to customize hooks, see:
+# https://github.com/brigade/overcommit#configuration
+#
+# Uncomment the following lines to make the configuration take effect.
+
+PreCommit:
+  ALL:
+    quiet: false
+  TrailingWhitespace:
+    enabled: true
+  HardTabs:
+    enabled: true
+  AuthorEmail:
+    enabled: false
+  AuthorName:
+    enabled: false
+  CssLint:
+    enabled: true
+  JsonSyntax:
+    enabled: true
+  EsLint:
+    enabled: true
+  MergeConflicts:
+    enabled: true
+  YamlLint:
+    enabled: true
+
+PostCheckout:
+  ALL:
+    quiet: false
+  NpmInstall:
+    enabled: true
+
+PostMerge:
+  NpmInstall:
+    enabled: true


### PR DESCRIPTION
ESlint config, based on `eslint:recommended`, with reactjs rules turned on.
Hound config, so the houndci bot knows to use eslint and not jshint.
Editor config, so text editors know what tabs to do


