### PR TITLE
tweaks to linter config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -37,6 +37,7 @@
     ]
   },
   "globals": {
-    "document": false
+    "document": false,
+    "React": false
   }
 }

--- a/.overcommit.yml
+++ b/.overcommit.yml
@@ -19,6 +19,8 @@
 PreCommit:
   ALL:
     quiet: false
+    exclude: &default_excludes
+      - 'node_modules/**/*'
   TrailingWhitespace:
     enabled: true
   HardTabs:


### PR DESCRIPTION
don't lint node_modules
and allow React global.
